### PR TITLE
Add Close() functions

### DIFF
--- a/fuji/fuji.go
+++ b/fuji/fuji.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/tjamet/goraw"
-	"github.com/tjamet/goraw/io"
+	gorawio "github.com/tjamet/goraw/io"
 	"github.com/tjamet/goraw/jpeg"
 )
 
@@ -16,6 +16,7 @@ var magic = []byte("FUJIFILMCCD-RAW")
 
 // Raw holds the context to decode a fujifilm raw file
 type Raw struct {
+	fd         *os.File
 	readerAt   io.ReaderAt
 	version    string
 	camera     string
@@ -29,7 +30,16 @@ func Open(filename string) (*Raw, error) {
 	if err != nil {
 		return nil, err
 	}
-	return New(fd)
+	raw, err := New(fd)
+	if err != nil {
+		return nil, err
+	}
+	raw.fd = fd
+	return raw, nil
+}
+
+func Close(r *Raw) error {
+	return r.Close()
 }
 
 // New instanciates a fujifilm raw handler from ReaderAt
@@ -54,11 +64,32 @@ func New(r io.ReaderAt) (*Raw, error) {
 
 // ExifReaderAt returns a direct reader to the Exif inside the raw
 func (r *Raw) ExifReaderAt() (io.ReaderAt, error) {
+	if r == nil {
+		return nil, fmt.Errorf("raw is nil")
+	}
+	if r.readerAt == nil {
+		return nil, os.ErrClosed
+	}
 	j, err := jpeg.New(gorawio.NewReaderAt(r.readerAt, int64(r.jpegStart)))
 	if err != nil {
 		return nil, err
 	}
 	return j.ExifReaderAt()
+}
+
+func (r *Raw) Close() error {
+	if r == nil {
+		return nil
+	}
+	if r.fd != nil {
+		err := r.fd.Close()
+		if err != nil {
+			return err
+		}
+		r.fd = nil
+	}
+	r.readerAt = nil
+	return nil
 }
 
 func init() {

--- a/fuji/fuji_test.go
+++ b/fuji/fuji_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/tjamet/goraw/fuji"
-	"github.com/tjamet/goraw/test-tools"
+	tools "github.com/tjamet/goraw/test-tools"
 )
 
 func TestNonFujiFileReportsError(t *testing.T) {
@@ -29,4 +29,27 @@ func TestFujiFileCanGetExif(t *testing.T) {
 	assert.NoError(t, err)
 	// fujifilm is big endian
 	assert.Equal(t, []byte("II"), header)
+}
+
+func TestFujiClose(t *testing.T) {
+	testFile := tools.DownloadRAW("http://www.rawsamples.ch/raws/fuji/RAW_FUJI_FINEPIX_X100.RAF")
+	r, err := fuji.Open(testFile)
+	assert.NoError(t, err)
+
+	// Test normal close
+	err = r.Close()
+	assert.NoError(t, err)
+
+	// Test double close (should not error)
+	err = r.Close()
+	assert.NoError(t, err)
+
+	// Test use after close (should error)
+	_, err = r.ExifReaderAt()
+	assert.Error(t, err)
+
+	// Test nil receiver close (should not error)
+	var nilRaw *fuji.Raw
+	err = nilRaw.Close()
+	assert.NoError(t, err)
 }

--- a/jpeg/jpeg_test.go
+++ b/jpeg/jpeg_test.go
@@ -1,0 +1,41 @@
+package jpeg_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tjamet/goraw/jpeg"
+)
+
+func TestJpegClose(t *testing.T) {
+	// Use a small local JPEG file or create a dummy one for the test
+	file, err := os.CreateTemp("", "testfile-*.jpg")
+	assert.NoError(t, err)
+	defer os.Remove(file.Name())
+	_, err = file.Write([]byte{0xff, 0xd8, 0xff, 0xe1, 0x00, 0x10, 'E', 'x', 'i', 'f', 0x00, 0x00})
+	assert.NoError(t, err)
+	file.Close()
+
+	f, err := os.Open(file.Name())
+	assert.NoError(t, err)
+	jpegDecoder, err := jpeg.New(f)
+	assert.NoError(t, err)
+
+	// Test normal close
+	err = jpegDecoder.Close()
+	assert.NoError(t, err)
+
+	// Test double close (should not error)
+	err = jpegDecoder.Close()
+	assert.NoError(t, err)
+
+	// Test use after close (should error)
+	_, err = jpegDecoder.ExifReaderAt()
+	assert.Error(t, err)
+
+	// Test nil receiver close (should not error)
+	var nilJpeg *jpeg.JPEG
+	err = nilJpeg.Close()
+	assert.NoError(t, err)
+}

--- a/raw.go
+++ b/raw.go
@@ -10,6 +10,7 @@ import (
 // Decoder defines the interface to implement a new raw decoder
 type Decoder interface {
 	ExifReaderAt() (io.ReaderAt, error)
+	Close() error
 }
 
 type format struct {
@@ -28,6 +29,13 @@ func Open(filename string) (Decoder, error) {
 		return nil, err
 	}
 	return New(fd)
+}
+
+func Close(r Decoder) error {
+	if r == nil {
+		return fmt.Errorf("decoder is nil")
+	}
+	return r.Close()
 }
 
 // New instanciates a decoder from a ReaderAt by detecting its format

--- a/raw_test.go
+++ b/raw_test.go
@@ -1,0 +1,33 @@
+package goraw_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tjamet/goraw"
+	_ "github.com/tjamet/goraw/fuji"
+	tools "github.com/tjamet/goraw/test-tools"
+)
+
+func TestGenericClose(t *testing.T) {
+	testFile := tools.DownloadRAW("http://www.rawsamples.ch/raws/fuji/RAW_FUJI_FINEPIX_X100.RAF")
+	decoder, err := goraw.Open(testFile)
+	assert.NoError(t, err)
+
+	// Test normal close
+	err = goraw.Close(decoder)
+	assert.NoError(t, err)
+
+	// Test double close (should not error)
+	err = goraw.Close(decoder)
+	assert.NoError(t, err)
+
+	// Test use after close (should error)
+	_, err = decoder.ExifReaderAt()
+	assert.Error(t, err)
+
+	// Test nil decoder close (should error)
+	var nilDecoder goraw.Decoder
+	err = goraw.Close(nilDecoder)
+	assert.Error(t, err)
+}

--- a/tiff/tiff_test.go
+++ b/tiff/tiff_test.go
@@ -1,0 +1,32 @@
+package tiff_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	tools "github.com/tjamet/goraw/test-tools"
+	"github.com/tjamet/goraw/tiff"
+)
+
+func TestTiffClose(t *testing.T) {
+	testFile := tools.DownloadRAW("http://www.rawsamples.ch/raws/nikon/RAW_NIKON_D1.NEF")
+	r, err := tiff.Open(testFile)
+	assert.NoError(t, err)
+
+	// Test normal close
+	err = r.Close()
+	assert.NoError(t, err)
+
+	// Test double close (should not error)
+	err = r.Close()
+	assert.NoError(t, err)
+
+	// Test use after close (should error)
+	_, err = r.ExifReaderAt()
+	assert.Error(t, err)
+
+	// Test nil receiver close (should not error)
+	var nilRaw *tiff.Raw
+	err = nilRaw.Close()
+	assert.NoError(t, err)
+}


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add a function to retrieve exif offset within the file (#4)
</summary>
While many RAW are direct TIFF containing the EXIF, this is not the case
for files like jpeg or fuji.

JPEG exif is located in the middle of the file and FUJI uses the embedded jpeg preview
to store the exif information.

Several exif metadata like the `Thumbnail Offset` refers to the offset compared to the root
of the exif data (i.e. number of bytes between the exif marker and the actual data).

Exposing those functions helps library users to compute the offset since the begining of the file
</details>
</details>
</details>