### PR TITLE
[need #3] Add a function to retrieve exif offset within the file

### DIFF
--- a/fuji/fuji_test.go
+++ b/fuji/fuji_test.go
@@ -53,3 +53,12 @@ func TestFujiClose(t *testing.T) {
 	err = nilRaw.Close()
 	assert.NoError(t, err)
 }
+
+func TestFujiExifOffset(t *testing.T) {
+	testFile := tools.DownloadRAW("http://www.rawsamples.ch/raws/fuji/RAW_FUJI_FINEPIX_X100.RAF")
+	r, err := fuji.Open(testFile)
+	assert.NoError(t, err)
+	offset, err := r.ExifOffset()
+	assert.NoError(t, err)
+	assert.Equal(t, int64(160), offset)
+}

--- a/raw.go
+++ b/raw.go
@@ -10,6 +10,7 @@ import (
 // Decoder defines the interface to implement a new raw decoder
 type Decoder interface {
 	ExifReaderAt() (io.ReaderAt, error)
+	ExifOffset() (int64, error)
 	Close() error
 }
 

--- a/tiff/tiff.go
+++ b/tiff/tiff.go
@@ -58,6 +58,13 @@ func (r *Raw) Close() error {
 	return nil
 }
 
+func (r *Raw) ExifOffset() (int64, error) {
+	if r == nil {
+		return 0, fmt.Errorf("raw is nil")
+	}
+	return 0, nil
+}
+
 func init() {
 	goraw.RegisterFormat("tiff", []byte("MM"), func(r io.ReaderAt) (goraw.Decoder, error) { return New(r) })
 	goraw.RegisterFormat("tiff", []byte("II"), func(r io.ReaderAt) (goraw.Decoder, error) { return New(r) })


### PR DESCRIPTION
While many RAW are direct TIFF containing the EXIF, this is not the case
for files like jpeg or fuji.

JPEG exif is located in the middle of the file and FUJI uses the embedded jpeg preview
to store the exif information.

Several exif metadata like the `Thumbnail Offset` refers to the offset compared to the root
of the exif data (i.e. number of bytes between the exif marker and the actual data).

Exposing those functions helps library users to compute the offset since the begining of the file
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
Add Close() functions (#3)
</summary>

</details>
</details>
</details>